### PR TITLE
Changed commands using chaos-report.json 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Once installed, a new `report` subcommand will be made available to the
 `chaos` command, use it as follows:
 
 ```
-$ chaos report --export-format=html5 chaos-report.json report.html
+$ chaos report --export-format=html5 journal.json report.html
 ```
 
 or, for a PDF document:
 
 ```
-$ chaos report --export-format=pdf chaos-report.json report.pdf
+$ chaos report --export-format=pdf journal.json report.pdf
 ```
 
 You can also generate a single report from many journals at once:


### PR DESCRIPTION
Updated the report name from chaos-report.json to journal.json within the commands that tried to use it - proof of concept below:

<img width="841" alt="Screenshot 2021-08-06 at 08 53 27" src="https://user-images.githubusercontent.com/74975634/128478654-a19237ec-95df-4a7c-a0da-270a9dd8f408.png">

Signed-off-by: Charlie Moon <charlie@chaosiq.io>

closes: #31 