### PR TITLE
Updated Docker Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PDF or HTML document.
 
 Install this package as any other Python packages:
 
-```
+```console
 $ pip install -U chaostoolkit-reporting
 ```
 
@@ -39,37 +39,47 @@ You will also need to [install some additional dependencies](uni-install.md) tha
 Once installed, a new `report` subcommand will be made available to the
 `chaos` command, use it as follows:
 
-```
+```console
 $ chaos report --export-format=html5 journal.json report.html
 ```
 
 or, for a PDF document:
 
-```
+```console
 $ chaos report --export-format=pdf journal.json report.pdf
 ```
 
 You can also generate a single report from many journals at once:
 
-```
+```console
 $ chaos report --export-format=pdf journal-1.json journal-2 journal-3 report.pdf
 ```
 
-Or more succintly:
+Or more succinctly:
 
-```
+```console
 $ chaos report --export-format=pdf journal-*.json report.pdf
 ```
 
 ## Download a Docker Image
 
 As the dependencies for this plugin can be difficult to get right, we also
-provide a docker image. Note that this image is rather big with 1.4Gb to
-pull.
+provide a docker image - note that this image is rather big with 1.4Gb to
+pull. You can install `Docker` from the [Docker Hub][dockerhub].
+
+[dockerhub]: https://hub.docker.com/search?q=&type=edition&offering=community
 
 ```console
 $ docker pull chaostoolkit/reporting
 ```
+
+If the following error message is received, you may have an invalid installation of `Docker`:
+
+```console
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+To resolve this, re-install `Docker` from the [Docker Hub][dockerhub], launch the application and grant it privileged access.
 
 ### Use a Docker container
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,6 @@ pull. You can install `Docker` from the [Docker Hub][dockerhub].
 $ docker pull chaostoolkit/reporting
 ```
 
-If the following error message is received, you may have an invalid installation of `Docker`:
-
-```console
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
-
-To resolve this, re-install `Docker` from the [Docker Hub][dockerhub], launch the application and grant it privileged access.
-
 ### Use a Docker container
 
 To generate a PDF report using the Docker image you must first ensure that you are running the command from where the `journal.json`


### PR DESCRIPTION
When installing `Docker`, I had an invalid installation that gave the following error:
`Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`

I found that this was caused by my installation - via `$ brew install docker` - and that a proper installation method was required as well as for the user to grant privileged access.

Signed-off-by: Charlie Moon <charlie@chaosiq.io>

closes: #35 