### PR TITLE
fix: changed how we extract major.minor from pandoc semver as they do…

### DIFF
--- a/chaosreport/__init__.py
+++ b/chaosreport/__init__.py
@@ -310,7 +310,7 @@ def save_report(
         extra_args = []
 
         pandoc_version = pypandoc.get_pandoc_version()
-        major, minor, _ = pandoc_version.split(".", 2)
+        major, minor = pandoc_version.split(".")[0:2]
         if int(major) == 2 and int(minor) < 19:
             extra_args.append("--self-contained")
         else:


### PR DESCRIPTION
Issue #48 reports a failure in CTK-reporting when it tries to extract the `major` and `minor` versions from the pandoc semver string. The issue is that not all releases have the semver pattern of `major.minor.patch`. As a result if you are running pandoc latest realease version `3.5` then CTK-reporing will fail as there are not enough values to unpack since there is no patch part to the semver version.

This fix changed how we extract and instead just unpacks major and minor into variables using a slice. This should be fine as we were just throwing away the rest of the semver string anyway.